### PR TITLE
bootstrap4 radio/checkbox selects fix restoring checked value on update

### DIFF
--- a/bootstrap4/package.js
+++ b/bootstrap4/package.js
@@ -1,7 +1,7 @@
 /* eslint-env meteor */
 Package.describe({
   name: 'communitypackages:autoform-bootstrap4',
-  version: '1.0.5',
+  version: '1.0.6',
   // Brief, one-line summary of the package.
   summary: 'Bootstrap 4 theme for aldeed:autoform',
   // URL to the Git repository containing the source code for this package.

--- a/bootstrap4/templates/bootstrap4/inputTypes/select-checkbox-inline/select-checkbox-inline.js
+++ b/bootstrap4/templates/bootstrap4/inputTypes/select-checkbox-inline/select-checkbox-inline.js
@@ -5,7 +5,7 @@ import './select-checkbox-inline.html'
 
 Template.afCheckboxGroupInline_bootstrap4.helpers({
   atts: function (index) {
-    const saag = selectedAttsAdjustGroup.call(this)
+    const saag = selectedAttsAdjustGroup.call(this, index)
     if (saag.id) {
       saag.id = `${saag.id}-${index}`
     }

--- a/bootstrap4/templates/bootstrap4/inputTypes/select-checkbox/select-checkbox.js
+++ b/bootstrap4/templates/bootstrap4/inputTypes/select-checkbox/select-checkbox.js
@@ -5,7 +5,7 @@ import './select-checkbox.html'
 
 Template.afCheckboxGroup_bootstrap4.helpers({
   atts: function (index) {
-    const saag = selectedAttsAdjustGroup.call(this)
+    const saag = selectedAttsAdjustGroup.call(this, index)
     if (saag.id) {
       saag.id = `${saag.id}-${index}`
     }

--- a/bootstrap4/templates/bootstrap4/inputTypes/select-radio-inline/select-radio-inline.js
+++ b/bootstrap4/templates/bootstrap4/inputTypes/select-radio-inline/select-radio-inline.js
@@ -1,22 +1,15 @@
 import { Template } from 'meteor/templating'
-import { omit } from '../../../../utils/omit'
+import { selectedAttsAdjustGroup } from '../../../../utils/selectedAttsAdjust'
 import './select-radio-inline.html'
 
 Template.afRadioGroupInline_bootstrap4.helpers({
   atts (index) {
-    const atts = omit(this.atts, 'data-schema-key')
-    if (this.selected) {
-      atts.checked = ''
+    const saag = selectedAttsAdjustGroup.call(this, index)
+    if (saag.id) {
+      saag.id = `${saag.id}-${index}`
     }
-
-    atts.class = atts.class || ''
-    atts.class = `${atts.class} form-check-input custom-control-input`
-
-    if (atts.id) {
-      atts.id = `${atts.id}-${index}`
-    }
-
-    return atts
+    saag.class = `${saag.class || ''} custom-control-input`
+    return saag
   },
   dsk () {
     return { 'data-schema-key': this.atts['data-schema-key'] }

--- a/bootstrap4/templates/bootstrap4/inputTypes/select-radio/select-radio.js
+++ b/bootstrap4/templates/bootstrap4/inputTypes/select-radio/select-radio.js
@@ -5,7 +5,7 @@ import './select-radio.html'
 
 Template.afRadioGroup_bootstrap4.helpers({
   atts: function (index) {
-    const saag = selectedAttsAdjustGroup.call(this)
+    const saag = selectedAttsAdjustGroup.call(this, index)
     if (saag.id) {
       saag.id = `${saag.id}-${index}`
     }

--- a/bootstrap4/utils/selectedAttsAdjust.js
+++ b/bootstrap4/utils/selectedAttsAdjust.js
@@ -1,14 +1,14 @@
-export const selectedAttsAdjust = function selectedAttsAdjust () {
+export const selectedAttsAdjust = function selectedAttsAdjust (index) {
   const atts = { ...this.atts }
-  if (this.selected) {
+  if (this.selected || this.items?.[index]?.selected) {
     atts.checked = ''
   }
   return atts
 }
 
-export const selectedAttsAdjustGroup = function selectedAttsAdjustGroup () {
+export const selectedAttsAdjustGroup = function selectedAttsAdjustGroup (index) {
   const self = this
-  const atts = selectedAttsAdjust.call(self)
+  const atts = selectedAttsAdjust.call(self, index)
   // remove data-schema-key attribute because we put it
   // on the entire group
   delete atts['data-schema-key']


### PR DESCRIPTION
Related issue has previously been started in the AutoForm repo: https://github.com/Meteor-Community-Packages/meteor-autoform/issues/1703

The issue was, however, caused by the theme not restoring the select values correctly and consistently for the following components:

- `select-radio`
- `select-radio-inline`
- `select-checkbox`
- `select-checkbox-inline`

We now use a fallback, where the index is passed to search in the `items` for the `selected` value, if `this.selected` fails